### PR TITLE
Cleanup flash offsets

### DIFF
--- a/dpedal_config/src/lib.rs
+++ b/dpedal_config/src/lib.rs
@@ -4,12 +4,12 @@ pub mod web_config_protocol;
 
 // Memory layout
 pub const RP2040_FLASH_OFFSET: usize = 0x10000000;
-pub const RP2040_FLASH_SIZE: usize = 1024 * 1024 * 16; // 16 MiB
+pub const PICO_FLASH_SIZE: usize = 1024 * 1024 * 2; // 2 MiB
 
 pub const FIRMWARE_OFFSET: usize = 0;
-pub const FIRMWARE_SIZE: usize = 1024 * 1024 * 15; // 15 MiB
-pub const CONFIG_OFFSET: usize = 1024 * 1024 * 15;
-pub const CONFIG_SIZE: usize = 1024 * 16; // 10 KiB
+pub const FIRMWARE_SIZE: usize = 1024 * 2000; // 2000 KiB
+pub const CONFIG_OFFSET: usize = 1024 * 2000;
+pub const CONFIG_SIZE: usize = 1024 * 16; // 16 KiB // TODO: give more space to config, currently increasing this causes problems, see dpedal_firmware/src/config.rs
 
 use arrayvec::{ArrayString, ArrayVec};
 use defmt::Format;
@@ -24,6 +24,7 @@ const fn assert_config_fits_in_flash() {
 
 const fn assert_config_size_fits_into_writable_flash_blocks() {
     // Flash can only be written in blocks of 4096 bytes.
+    assert!(CONFIG_OFFSET.is_multiple_of(4096));
     assert!(CONFIG_SIZE.is_multiple_of(4096));
 }
 

--- a/dpedal_firmware/src/config.rs
+++ b/dpedal_firmware/src/config.rs
@@ -1,6 +1,6 @@
 use arrayvec::ArrayVec;
 use defmt::error;
-use dpedal_config::{ArchivedConfig, CONFIG_OFFSET, CONFIG_SIZE, Config, RP2040_FLASH_SIZE};
+use dpedal_config::{ArchivedConfig, CONFIG_OFFSET, CONFIG_SIZE, Config, PICO_FLASH_SIZE};
 use embassy_rp::{
     Peri,
     flash::{Blocking, Flash},
@@ -12,7 +12,7 @@ use rkyv::{rancor::Failure, util::Align};
 pub static CONFIG: Mutex<CriticalSectionRawMutex, Option<Config>> = Mutex::new(None);
 
 pub struct ConfigFlash {
-    flash: Flash<'static, FLASH, Blocking, RP2040_FLASH_SIZE>,
+    flash: Flash<'static, FLASH, Blocking, PICO_FLASH_SIZE>,
 }
 
 impl ConfigFlash {

--- a/dpedal_flash/build.rs
+++ b/dpedal_flash/build.rs
@@ -1,7 +1,10 @@
 use std::{env, process::Command};
 
 fn main() {
-    for file in std::fs::read_dir("../dpedal_firmware").unwrap() {
+    for file in std::fs::read_dir("../dpedal_firmware")
+        .unwrap()
+        .chain(std::fs::read_dir("../dpedal_config").unwrap())
+    {
         let path = file.unwrap().path();
 
         if path.file_name().unwrap().to_str().unwrap() != "target" {


### PR DESCRIPTION
Those 15 MiB values were taken from another RP2040 based device with a sufficiently large flash chip.
The pico only has 2MIB flash so its not clear why exactly this worked, but I assume the memory space loops around at 2MiB.
This PR cleans up this mess by moving everything within 2MiB.