### PR TITLE
Swap arrayvec->heapless and rkyv->postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli 0.32.3",
+ "gimli",
 ]
 
 [[package]]
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -46,15 +46,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -81,18 +81,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "askama"
@@ -118,7 +115,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc-hash",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -128,7 +125,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
- "winnow 0.7.14",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -178,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -248,32 +254,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
-name = "bytecheck"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "rancor",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "byteorder"
@@ -283,15 +266,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.50"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -305,9 +288,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -315,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -327,27 +310,36 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crc32fast"
@@ -357,6 +349,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -403,7 +401,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -419,9 +417,8 @@ dependencies = [
 name = "dpedal_config"
 version = "0.0.2"
 dependencies = [
- "arrayvec",
  "defmt",
- "rkyv",
+ "heapless 0.8.0",
  "serde",
  "strum",
  "usbd-hid",
@@ -431,16 +428,16 @@ dependencies = [
 name = "dpedal_flash"
 version = "0.0.7"
 dependencies = [
- "arrayvec",
  "clap",
  "dpedal_config",
  "goblin",
+ "heapless 0.8.0",
  "kdl",
  "kdl_config",
  "kdl_config_derive",
  "miette",
  "picoboot-rs",
- "rkyv",
+ "postcard",
  "rusb",
  "ssmarshal",
  "uf2-decode",
@@ -451,6 +448,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -476,21 +485,21 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -503,6 +512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,52 +528,41 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
-]
-
-[[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-dependencies = [
- "fallible-iterator",
- "indexmap 1.9.3",
- "stable_deref_trait",
+ "slab",
 ]
 
 [[package]]
@@ -566,6 +570,11 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "goblin"
@@ -580,18 +589,21 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -608,7 +620,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
  "serde",
 ]
 
@@ -617,6 +629,25 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heapless"
@@ -624,7 +655,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -708,12 +740,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "futures-core",
  "http",
  "http-body",
  "hyper",
@@ -724,28 +755,18 @@ dependencies = [
 
 [[package]]
 name = "id-arena"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -767,9 +788,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kdl"
@@ -785,9 +806,10 @@ dependencies = [
 [[package]]
 name = "kdl_config"
 version = "0.1.0"
-source = "git+https://github.com/rukai/kdl_config#3c75e59e6e3fbedd56c8cc3357ea01a15ca6938c"
+source = "git+https://github.com/rukai/kdl_config#d06b464b70fac49821b05cc31a4f9d22d2510161"
 dependencies = [
  "arrayvec",
+ "heapless 0.8.0",
  "kdl",
  "miette",
  "thiserror",
@@ -796,12 +818,12 @@ dependencies = [
 [[package]]
 name = "kdl_config_derive"
 version = "0.1.0"
-source = "git+https://github.com/rukai/kdl_config#3c75e59e6e3fbedd56c8cc3357ea01a15ca6938c"
+source = "git+https://github.com/rukai/kdl_config#d06b464b70fac49821b05cc31a4f9d22d2510161"
 dependencies = [
  "proc-macro2",
  "quote",
  "stringcase",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -818,9 +840,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libusb1-sys"
@@ -836,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -863,9 +885,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miette"
@@ -894,7 +916,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -932,26 +954,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "munge"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
-dependencies = [
- "munge_macro",
-]
-
-[[package]]
-name = "munge_macro"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]
@@ -1038,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1050,9 +1052,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -1097,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1121,9 +1123,22 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless 0.7.17",
+ "serde",
+]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -1144,54 +1159,25 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rancor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
-dependencies = [
- "ptr_meta",
 ]
 
 [[package]]
@@ -1220,42 +1206,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "rend"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.8.12"
-source = "git+https://github.com/rukai/rkyv?branch=add_support_for_arraystring#075aa221d0eb0a71d7e999e65735d1ca298ecc47"
-dependencies = [
- "arrayvec",
- "bytecheck",
- "hashbrown 0.16.1",
- "munge",
- "ptr_meta",
- "rancor",
- "rend",
- "rkyv_derive",
- "tinyvec",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.8.12"
-source = "git+https://github.com/rukai/rkyv?branch=add_support_for_arraystring#075aa221d0eb0a71d7e999e65735d1ca298ecc47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1270,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -1281,12 +1232,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustix"
-version = "1.1.2"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 2.10.0",
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1295,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -1322,7 +1282,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1358,20 +1318,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1405,10 +1365,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1417,12 +1378,6 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "site"
@@ -1438,6 +1393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,12 +1406,21 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1499,7 +1469,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1536,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1573,44 +1543,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1625,20 +1580,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1649,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1669,7 +1624,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1729,15 +1684,15 @@ checksum = "ca77d41ab27e3fa45df42043f96c79b80c6d8632eed906b54681d8d47ab00623"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1763,7 +1718,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 
@@ -1824,31 +1779,31 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walrus"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff282e73d21b86a9d397f42570d158eb9e5c521d0ead4d13cd049fd7cb45c467"
+checksum = "643cc295c2bf4c34d36c2bbaddee48c56a15de3a35e7021b95ceb6a936a493ac"
 dependencies = [
  "anyhow",
- "gimli 0.26.2",
+ "gimli",
  "id-arena",
  "leb128",
  "log",
  "rayon",
  "walrus-macro",
  "wasm-encoder",
- "wasmparser",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
 name = "walrus-macro"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef06db404cbaed87cb25fd2ca3a62502af485f43383c9641ffcf1479d02fffd"
+checksum = "cef8d704ff46ad931a2cd1f7a504fe43ffb8e968d931e179ff18d0dff4949bd5"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1859,9 +1814,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03794299fa80bda34aef2784a496c6440fbc75fb1977c4e05750ddcd617e5a09"
+checksum = "a468565fe14ad40511a77eb46b743d88c7a8dc6e2035a670abb4555a32d9a3e7"
 dependencies = [
  "anyhow",
  "base64",
@@ -1872,26 +1827,26 @@ dependencies = [
  "serde_json",
  "walrus",
  "wasm-bindgen-shared",
- "wasmparser",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.240.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -1900,9 +1855,22 @@ version = "0.240.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.12.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indexmap",
  "semver",
  "serde",
 ]
@@ -2007,29 +1975,35 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 
 [workspace.dependencies]
-rkyv = { version = "0.8.10", default-features = false, features = ["arrayvec-0_7", "bytecheck"], git = "https://github.com/rukai/rkyv", branch = "add_support_for_arraystring" }
+heapless = { version = "0.8", default-features = false, features = ["serde"] }
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/dpedal_config/Cargo.toml
+++ b/dpedal_config/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2024"
 repository = "https://github.com/rukai/dpedal"
 
 [dependencies]
-rkyv.workspace = true
-arrayvec = { version = "0.7.6", default-features = false, features = ["serde"] }
+heapless.workspace = true
 usbd-hid = { version = "0.9.0", default-features = false }
 serde = { version = "1.0.0", default-features = false, features = ["derive"] }
 defmt = "1"

--- a/dpedal_config/src/lib.rs
+++ b/dpedal_config/src/lib.rs
@@ -11,14 +11,14 @@ pub const FIRMWARE_SIZE: usize = 1024 * 2000; // 2000 KiB
 pub const CONFIG_OFFSET: usize = 1024 * 2000;
 pub const CONFIG_SIZE: usize = 1024 * 12; // 12 KiB // TODO: This is used to allocate space for config stored under different conditions e.g. serialized by different serialization techniques. At high config usage we could get weird failures. Need to clarify these usages.
 
-use arrayvec::{ArrayString, ArrayVec};
 use defmt::Format;
-use rkyv::{Archive, Deserialize, Serialize};
+use heapless::{String, Vec};
+use serde::{Deserialize, Serialize};
 use strum::{EnumIter, EnumString, IntoEnumIterator, IntoStaticStr};
 
 const fn assert_config_fits_in_flash() {
-    // TODO: This isnt actually accurate, since the data will be serialized into rkyv format first.
-    //       Is there a way to calculate the maximum possible size in rkyv format?
+    // TODO: This isnt actually accurate, since the data will be serialized into postcard format first.
+    //       Is there a way to calculate the maximum possible size in postcard format?
     assert!(core::mem::size_of::<Config>() <= CONFIG_SIZE);
 }
 
@@ -35,39 +35,36 @@ pub const MAX_PROFILES: usize = 5;
 pub const MAX_NICKNAME_LEN: usize = 50;
 pub const MAX_PIN_REMAPPINGS: usize = 6;
 
-#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Clone)]
-#[rkyv(derive(Debug))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Config {
     pub version: u32,
-    pub nickname: ArrayString<MAX_NICKNAME_LEN>,
+    pub nickname: String<MAX_NICKNAME_LEN>,
     pub device: Device,
     pub color: u32,
-    pub profiles: ArrayVec<Profile, MAX_PROFILES>,
-    pub pin_remappings: ArrayVec<PinRemapping, MAX_PIN_REMAPPINGS>,
+    pub profiles: Vec<Profile, MAX_PROFILES>,
+    pub pin_remappings: Vec<PinRemapping, MAX_PIN_REMAPPINGS>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             version: Default::default(),
-            nickname: ArrayString::from("my DPedal").unwrap(),
+            nickname: String::try_from("my DPedal").unwrap(),
             device: Default::default(),
             color: 0x1790e3,
-            profiles: ArrayVec::from_iter([Profile::default()]),
+            profiles: Vec::from_iter([Profile::default()]),
             pin_remappings: Default::default(),
         }
     }
 }
 
-#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Default, Clone, IntoStaticStr)]
-#[rkyv(derive(Debug))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone, IntoStaticStr)]
 pub enum Device {
     #[default]
     DpedalV3,
 }
 
-#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
-#[rkyv(derive(Debug))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct PinRemapping {
     pub input: DpedalInput,
     // TODO: make u8
@@ -76,68 +73,63 @@ pub struct PinRemapping {
 
 pub const MAX_MAPPINGS: usize = 12;
 pub const MAX_COMPUTER_INPUTS: usize = 25;
-#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Clone)]
-#[rkyv(derive(Debug))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Profile {
-    pub mappings: ArrayVec<Mapping, MAX_MAPPINGS>,
+    pub mappings: Vec<Mapping, MAX_MAPPINGS>,
 }
 
 impl Profile {
     pub fn empty() -> Self {
         Self {
-            mappings: ArrayVec::new(),
+            mappings: Vec::new(),
         }
     }
 
     pub fn mouse_move() -> Self {
         Self {
-            mappings: ArrayVec::from_iter([
+            mappings: Vec::from_iter([
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadLeft]),
+                    input_set: Vec::from_iter([DpedalInput::DpadLeft]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
-                        MouseInput::MoveLeft(300),
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(MouseInput::MoveLeft(
+                        300,
+                    ))]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadRight]),
+                    input_set: Vec::from_iter([DpedalInput::DpadRight]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
-                        MouseInput::MoveRight(300),
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(MouseInput::MoveRight(
+                        300,
+                    ))]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadUp]),
+                    input_set: Vec::from_iter([DpedalInput::DpadUp]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
-                        MouseInput::MoveUp(300),
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(MouseInput::MoveUp(
+                        300,
+                    ))]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadDown]),
+                    input_set: Vec::from_iter([DpedalInput::DpadDown]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
-                        MouseInput::MoveDown(300),
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(MouseInput::MoveDown(
+                        300,
+                    ))]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonLeft]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonLeft]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
-                        MouseInput::ClickLeft,
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(MouseInput::ClickLeft)]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonRight]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonRight]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
-                        MouseInput::ClickRight,
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(MouseInput::ClickRight)]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonRight]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonRight]),
                     mode: MappingMode::OnHold { hold_ms: 2000 },
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Control(
+                    output_sequence: Vec::from_iter([ComputerInput::Control(
                         DPedalControl::SetProfile(0),
                     )]),
                 },
@@ -147,54 +139,52 @@ impl Profile {
 
     pub fn arrow_keys() -> Self {
         Self {
-            mappings: ArrayVec::from_iter([
+            mappings: Vec::from_iter([
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadLeft]),
+                    input_set: Vec::from_iter([DpedalInput::DpadLeft]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Keyboard(
+                    output_sequence: Vec::from_iter([ComputerInput::Keyboard(
                         KeyboardInput::LeftArrow,
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadRight]),
+                    input_set: Vec::from_iter([DpedalInput::DpadRight]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Keyboard(
+                    output_sequence: Vec::from_iter([ComputerInput::Keyboard(
                         KeyboardInput::RightArrow,
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadUp]),
+                    input_set: Vec::from_iter([DpedalInput::DpadUp]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Keyboard(
+                    output_sequence: Vec::from_iter([ComputerInput::Keyboard(
                         KeyboardInput::UpArrow,
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadDown]),
+                    input_set: Vec::from_iter([DpedalInput::DpadDown]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Keyboard(
+                    output_sequence: Vec::from_iter([ComputerInput::Keyboard(
                         KeyboardInput::DownArrow,
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonLeft]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonLeft]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([
+                    output_sequence: Vec::from_iter([
                         ComputerInput::Keyboard(KeyboardInput::LeftShift),
                         ComputerInput::Keyboard(KeyboardInput::Tab),
                     ]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonRight]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonRight]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Keyboard(
-                        KeyboardInput::Tab,
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Keyboard(KeyboardInput::Tab)]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonRight]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonRight]),
                     mode: MappingMode::OnHold { hold_ms: 2000 },
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Control(
+                    output_sequence: Vec::from_iter([ComputerInput::Control(
                         DPedalControl::SetProfile(0),
                     )]),
                 },
@@ -204,12 +194,12 @@ impl Profile {
 
     pub fn macro_demo() -> Self {
         Self {
-            mappings: ArrayVec::from_iter([
+            mappings: Vec::from_iter([
                 // Left button: move mouse in a 200px square (at 200px/s, each side takes 1000ms)
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonLeft]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonLeft]),
                     mode: MappingMode::MacroOnPress,
-                    output_sequence: ArrayVec::from_iter([
+                    output_sequence: Vec::from_iter([
                         ComputerInput::Mouse(MouseInput::MoveRight(500)),
                         ComputerInput::Control(DPedalControl::AfterMillisRelease(500)),
                         ComputerInput::Mouse(MouseInput::MoveDown(500)),
@@ -222,9 +212,9 @@ impl Profile {
                 },
                 // Right button: Ctrl+L, type "dpedal.com", Enter
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonRight]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonRight]),
                     mode: MappingMode::MacroOnPress,
-                    output_sequence: ArrayVec::from_iter([
+                    output_sequence: Vec::from_iter([
                         ComputerInput::Keyboard(KeyboardInput::LeftControl),
                         ComputerInput::Keyboard(KeyboardInput::L),
                         ComputerInput::Control(DPedalControl::AfterMillisRelease(100)),
@@ -259,46 +249,46 @@ impl Profile {
 impl Default for Profile {
     fn default() -> Self {
         Self {
-            mappings: ArrayVec::from_iter([
+            mappings: Vec::from_iter([
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadLeft]),
+                    input_set: Vec::from_iter([DpedalInput::DpadLeft]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(
                         MouseInput::ScrollLeft(20),
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadRight]),
+                    input_set: Vec::from_iter([DpedalInput::DpadRight]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(
                         MouseInput::ScrollRight(20),
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadUp]),
+                    input_set: Vec::from_iter([DpedalInput::DpadUp]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
-                        MouseInput::ScrollUp(20),
-                    )]),
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(MouseInput::ScrollUp(
+                        20,
+                    ))]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::DpadDown]),
+                    input_set: Vec::from_iter([DpedalInput::DpadDown]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Mouse(
+                    output_sequence: Vec::from_iter([ComputerInput::Mouse(
                         MouseInput::ScrollDown(20),
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonLeft]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonLeft]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Keyboard(
+                    output_sequence: Vec::from_iter([ComputerInput::Keyboard(
                         KeyboardInput::PageUp,
                     )]),
                 },
                 Mapping {
-                    input_set: ArrayVec::from_iter([DpedalInput::ButtonRight]),
+                    input_set: Vec::from_iter([DpedalInput::ButtonRight]),
                     mode: MappingMode::OnPress,
-                    output_sequence: ArrayVec::from_iter([ComputerInput::Keyboard(
+                    output_sequence: Vec::from_iter([ComputerInput::Keyboard(
                         KeyboardInput::PageDown,
                     )]),
                 },
@@ -308,13 +298,12 @@ impl Default for Profile {
 }
 
 pub const MAX_DPEDAL_INPUTS: usize = 4;
-#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
-#[rkyv(derive(Debug))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct Mapping {
     /// The input_set produces:
     /// * a press event when (the last event was release OR there have been no events yet) AND all DpedalInput are held
     /// * a release event when the last event was press AND at least one DPedalInput is not held.
-    pub input_set: ArrayVec<DpedalInput, MAX_DPEDAL_INPUTS>,
+    pub input_set: Vec<DpedalInput, MAX_DPEDAL_INPUTS>,
 
     /// The output_sequence is triggered and/or terminated when the specified conditions in the input_set are met.
     pub mode: MappingMode,
@@ -322,23 +311,12 @@ pub struct Mapping {
     /// A sequence of ComputerInputs forming a simple key press or macro.
     /// Can contain just a single ComputerInput for use as a regular computer input instead of a macro.
     /// Once triggered, the output_sequence runs till completion or the terminate_on condition is met.
-    pub output_sequence: ArrayVec<ComputerInput, MAX_COMPUTER_INPUTS>,
+    pub output_sequence: Vec<ComputerInput, MAX_COMPUTER_INPUTS>,
 }
 
 #[derive(
-    Format,
-    Archive,
-    Deserialize,
-    Serialize,
-    Debug,
-    PartialEq,
-    Default,
-    Clone,
-    Copy,
-    EnumIter,
-    IntoStaticStr,
+    Format, Serialize, Deserialize, Debug, PartialEq, Default, Clone, Copy, EnumIter, IntoStaticStr,
 )]
-#[rkyv(derive(Debug))]
 pub enum MappingMode {
     /// The output_sequence is triggered on input_set press
     /// The output_sequence is terminated on input_set release or the output_sequence reaches its end
@@ -415,19 +393,8 @@ impl MappingMode {
 }
 
 #[derive(
-    Format,
-    Archive,
-    Deserialize,
-    Serialize,
-    Debug,
-    PartialEq,
-    Default,
-    Clone,
-    Copy,
-    EnumIter,
-    IntoStaticStr,
+    Format, Serialize, Deserialize, Debug, PartialEq, Default, Clone, Copy, EnumIter, IntoStaticStr,
 )]
-#[rkyv(derive(Debug))]
 pub enum DpedalInput {
     #[default]
     DpadUp,
@@ -464,8 +431,7 @@ impl DpedalInput {
     }
 }
 
-#[derive(Format, Archive, Deserialize, Serialize, Debug, PartialEq, Clone, Copy)]
-#[rkyv(derive(Debug))]
+#[derive(Format, Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub enum ComputerInput {
     Mouse(MouseInput),
     Keyboard(KeyboardInput),
@@ -473,19 +439,8 @@ pub enum ComputerInput {
 }
 
 #[derive(
-    Format,
-    Archive,
-    Deserialize,
-    Serialize,
-    Debug,
-    PartialEq,
-    Default,
-    Clone,
-    Copy,
-    EnumIter,
-    IntoStaticStr,
+    Format, Serialize, Deserialize, Debug, PartialEq, Default, Clone, Copy, EnumIter, IntoStaticStr,
 )]
-#[rkyv(derive(Debug))]
 pub enum MouseInput {
     /// The mouse will scroll up by this many pixels per second
     ScrollUp(i16),
@@ -529,19 +484,8 @@ impl MouseInput {
 }
 
 #[derive(
-    Format,
-    Archive,
-    Deserialize,
-    Serialize,
-    Debug,
-    PartialEq,
-    Default,
-    Clone,
-    Copy,
-    EnumIter,
-    EnumString,
+    Format, Serialize, Deserialize, Debug, PartialEq, Default, Clone, Copy, EnumIter, EnumString,
 )]
-#[rkyv(derive(Debug))]
 pub enum KeyboardInput {
     #[default]
     /// Keyboard a and A (Footnote 2)
@@ -992,19 +936,8 @@ const COMMON_KEYBOARD_INPUTS: [KeyboardInput; 93] = [
 ];
 
 #[derive(
-    Format,
-    Archive,
-    Deserialize,
-    Serialize,
-    Debug,
-    PartialEq,
-    Default,
-    Clone,
-    Copy,
-    EnumIter,
-    IntoStaticStr,
+    Format, Serialize, Deserialize, Debug, PartialEq, Default, Clone, Copy, EnumIter, IntoStaticStr,
 )]
-#[rkyv(derive(Debug))]
 pub enum DPedalControl {
     /// By default all ComputerInputs in the output_sequence are held until the terminate_on condition is met.
     /// However, when this variant is included in the output_sequence, all elements after this one are blocked.

--- a/dpedal_config/src/web_config_protocol.rs
+++ b/dpedal_config/src/web_config_protocol.rs
@@ -1,18 +1,18 @@
 use crate::CONFIG_SIZE;
-use arrayvec::ArrayVec;
+use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[expect(clippy::large_enum_variant)]
 pub enum Request {
     GetConfig,
-    SetConfig(ArrayVec<u8, CONFIG_SIZE>),
+    SetConfig(Vec<u8, CONFIG_SIZE>),
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[expect(clippy::large_enum_variant)]
 pub enum Response {
-    GetConfig(Result<ArrayVec<u8, CONFIG_SIZE>, ()>),
+    GetConfig(Result<Vec<u8, CONFIG_SIZE>, ()>),
     SetConfig,
     ProtocolError,
 }

--- a/dpedal_config_web_app/Cargo.lock
+++ b/dpedal_config_web_app/Cargo.lock
@@ -15,15 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,32 +37,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-
-[[package]]
-name = "bytecheck"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "rancor",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -81,9 +49,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -146,7 +114,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -162,9 +130,8 @@ dependencies = [
 name = "dpedal_config"
 version = "0.0.2"
 dependencies = [
- "arrayvec",
  "defmt",
- "rkyv",
+ "heapless 0.8.0",
  "serde",
  "strum",
  "usbd-hid",
@@ -174,15 +141,14 @@ dependencies = [
 name = "dpedal_config_web_app"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "console_error_panic_hook",
  "console_log",
  "dpedal_config",
  "futures",
+ "heapless 0.8.0",
  "js-sys",
  "log",
  "postcard",
- "rkyv",
  "ssmarshal",
  "strum",
  "wasm-bindgen",
@@ -211,9 +177,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -226,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -236,15 +202,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -253,38 +219,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -294,7 +260,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -326,12 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32 0.3.1",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -363,9 +323,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -388,53 +348,27 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "munge"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
-dependencies = [
- "munge_macro",
-]
-
-[[package]]
-name = "munge_macro"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postcard"
@@ -468,89 +402,25 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rancor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
-dependencies = [
- "ptr_meta",
-]
-
-[[package]]
-name = "rend"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
-name = "rkyv"
-version = "0.8.12"
-source = "git+https://github.com/rukai/rkyv?branch=add_support_for_arraystring#075aa221d0eb0a71d7e999e65735d1ca298ecc47"
-dependencies = [
- "arrayvec",
- "bytecheck",
- "hashbrown 0.16.1",
- "munge",
- "ptr_meta",
- "rancor",
- "rend",
- "rkyv_derive",
- "tinyvec",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.8.12"
-source = "git+https://github.com/rukai/rkyv?branch=add_support_for_arraystring#075aa221d0eb0a71d7e999e65735d1ca298ecc47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]
@@ -607,20 +477,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spin"
@@ -665,7 +529,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -681,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -692,53 +556,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "pin-project-lite",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -748,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -761,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usb-device"
@@ -803,7 +652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab457064302de0aca303a13cd520dcf035fdfd2aff713fa69d713d0a8e4291d8"
 dependencies = [
  "byteorder",
- "hashbrown 0.13.2",
+ "hashbrown",
  "log",
  "proc-macro2",
  "quote",
@@ -820,9 +669,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -833,11 +682,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -846,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -856,31 +706,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -888,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "webusb-web"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f25309f28e0a1e3144f1867ec5021e4955fd61768fbd717f216955152e00685"
+checksum = "946575140504f2f452d4f5518f6cefe4bd62117151e7878d47c46d1db2d12f8a"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -904,20 +754,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]

--- a/dpedal_config_web_app/Cargo.toml
+++ b/dpedal_config_web_app/Cargo.toml
@@ -14,8 +14,7 @@ wasm-bindgen-futures = "0.4"
 webusb-web = "0.4.1"
 postcard = { version = "1.1.3", features = ["use-std"] }
 dpedal_config = { path = "../dpedal_config"}
-rkyv = { version = "0.8.10", default-features = false, features = ["arrayvec-0_7", "bytecheck", "alloc"], git = "https://github.com/rukai/rkyv", branch = "add_support_for_arraystring" }
-arrayvec = "0.7"
+heapless = { version = "0.8", default-features = false, features = ["serde"] }
 
 # workaround https://gitlab.com/robigalia/ssmarshal/-/merge_requests/2
 # TODO: lets just eradicate this unmaintained thing from the dep tree entirely

--- a/dpedal_config_web_app/src/lib.rs
+++ b/dpedal_config_web_app/src/lib.rs
@@ -1,5 +1,4 @@
-use arrayvec::ArrayString;
-use arrayvec::ArrayVec;
+use dpedal_config::CONFIG_SIZE;
 use dpedal_config::ComputerInput;
 use dpedal_config::Config;
 use dpedal_config::DPedalControl;
@@ -21,7 +20,6 @@ use dpedal_config::web_config_protocol::Request;
 use dpedal_config::web_config_protocol::Response;
 use element_iterator::ElementChildIter;
 use log::Level;
-use rkyv::rancor::Error;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -197,14 +195,14 @@ async fn write_config(
     preserved: PreservedConfig,
 ) -> Result<(), String> {
     let profiles_container: Element = document.get_element("profiles-container");
-    let mut profiles = ArrayVec::new();
+    let mut profiles = heapless::Vec::new();
 
     for profile_section in ElementChildIter::new(&profiles_container) {
         let mut section_children = ElementChildIter::new(&profile_section);
         section_children.next(); // skip header_row
         let table = section_children.next().unwrap();
 
-        let mut mappings = ArrayVec::new();
+        let mut mappings = heapless::Vec::new();
 
         // Iterate over rows, skipping the header
         for row in ElementChildIter::new(&table).skip(1) {
@@ -215,26 +213,28 @@ async fn write_config(
             let input_cell: Element = cells.next().unwrap();
             let wrapper = input_cell.children().item(0).unwrap();
             let selects_container = wrapper.children().item(2).unwrap();
-            let input = ArrayVec::from_iter(ElementChildIter::new(&selects_container).map(
-                |wrapper: Element| {
+            let input = ElementChildIter::new(&selects_container)
+                .map(|wrapper: Element| {
                     let s: HtmlSelectElement =
                         wrapper.first_element_child().unwrap().dyn_into().unwrap();
                     DpedalInput::from_string(&s.value()).unwrap()
-                },
-            ));
+                })
+                .collect();
             let output_sequence = parse_output_cell(&cells.next().unwrap());
-            mappings.push(Mapping {
-                input_set: input,
-                mode,
-                output_sequence,
-            });
+            mappings
+                .push(Mapping {
+                    input_set: input,
+                    mode,
+                    output_sequence,
+                })
+                .unwrap();
         }
 
-        profiles.push(Profile { mappings });
+        profiles.push(Profile { mappings }).unwrap();
     }
 
     let name: HtmlInputElement = document.get_element("device_name");
-    let nickname = ArrayString::from(&name.value()).map_err(|_| {
+    let nickname = heapless::String::try_from(name.value().as_str()).map_err(|_| {
         format!(
             "nickname must be <= {MAX_NICKNAME_LEN} characters long, but was {} characters long",
             name.value().len()
@@ -253,8 +253,9 @@ async fn write_config(
         pin_remappings: preserved.pin_remappings,
     };
 
-    let config_bytes =
-        ArrayVec::from_iter(rkyv::to_bytes::<Error>(&config).unwrap().iter().cloned());
+    let config_bytes_std = postcard::to_stdvec(&config).unwrap();
+    let config_bytes: heapless::Vec<u8, CONFIG_SIZE> =
+        heapless::Vec::from_slice(&config_bytes_std).unwrap();
     device
         .send_request(&Request::SetConfig(config_bytes))
         .await?;
@@ -279,7 +280,7 @@ fn parse_mode_cell(mode_cell: &Element) -> MappingMode {
     MappingMode::from_string(&variant_name, &ms_value).unwrap_or_default()
 }
 
-fn parse_output_cell(output_cell: &Element) -> ArrayVec<ComputerInput, MAX_COMPUTER_INPUTS> {
+fn parse_output_cell(output_cell: &Element) -> heapless::Vec<ComputerInput, MAX_COMPUTER_INPUTS> {
     let wrapper = output_cell.children().item(0).unwrap();
     let container = wrapper.children().item(2).unwrap();
     ElementChildIter::new(&container)
@@ -327,11 +328,8 @@ async fn request_get_config(device: &Device) -> Result<Config, String> {
     let response = device.send_request(&Request::GetConfig).await?;
     match response {
         Response::GetConfig(config_bytes) => {
-            // TODO: Is Align required in some circumstances?
-            rkyv::from_bytes::<Config, rkyv::rancor::Error>(
-                &config_bytes.map_err(|e| format!("{e:?}"))?,
-            )
-            .map_err(|e| format!("{e:?}"))
+            postcard::from_bytes::<Config>(&config_bytes.map_err(|e| format!("{e:?}"))?)
+                .map_err(|e| format!("{e:?}"))
         }
         Response::SetConfig => panic!("Unexpected dpedal response"),
         Response::ProtocolError => panic!("dpedal protocol error"),
@@ -559,7 +557,7 @@ fn create_dpedal_input_select(document: &Document, value: &DpedalInput) -> HtmlS
 
 fn create_row_input(
     document: &Document,
-    inputs: &ArrayVec<DpedalInput, MAX_DPEDAL_INPUTS>,
+    inputs: &heapless::Vec<DpedalInput, MAX_DPEDAL_INPUTS>,
 ) -> Element {
     let td: Element = document.create_element("td");
 
@@ -597,7 +595,7 @@ fn create_row_input(
 
 fn create_row_output(
     document: &Document,
-    outputs: &ArrayVec<ComputerInput, MAX_COMPUTER_INPUTS>,
+    outputs: &heapless::Vec<ComputerInput, MAX_COMPUTER_INPUTS>,
 ) -> Element {
     let td: Element = document.create_element("td");
 
@@ -803,7 +801,7 @@ fn renumber_profiles(document: &Document) {
 struct PreservedConfig {
     version: u32,
     device: DPedalDevice,
-    pin_remappings: ArrayVec<PinRemapping, MAX_PIN_REMAPPINGS>,
+    pin_remappings: heapless::Vec<PinRemapping, MAX_PIN_REMAPPINGS>,
 }
 
 fn inject_css(document: &Document) {

--- a/dpedal_firmware/Cargo.lock
+++ b/dpedal_firmware/Cargo.lock
@@ -28,9 +28,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ascii-canvas"
@@ -58,9 +55,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "az"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "bare-metal"
@@ -106,9 +103,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -120,33 +117,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecheck"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "rancor",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -156,9 +130,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -228,7 +202,7 @@ checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -292,7 +266,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -303,7 +277,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -332,7 +306,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -377,9 +351,8 @@ dependencies = [
 name = "dpedal_config"
 version = "0.0.2"
 dependencies = [
- "arrayvec",
  "defmt",
- "rkyv",
+ "heapless 0.8.0",
  "serde",
  "strum",
  "usbd-hid",
@@ -389,7 +362,6 @@ dependencies = [
 name = "dpedal_firmware"
 version = "0.1.1"
 dependencies = [
- "arrayvec",
  "cortex-m",
  "cortex-m-rt",
  "defmt",
@@ -401,10 +373,10 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embassy-usb",
+ "heapless 0.8.0",
  "panic-probe",
  "portable-atomic",
  "postcard",
- "rkyv",
  "static_cell",
  "usbd-hid",
 ]
@@ -418,7 +390,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.5.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
@@ -434,7 +406,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.9.1"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "cordyceps",
  "cortex-m",
@@ -448,28 +420,28 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "embassy-executor-timer-queue"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 
 [[package]]
 name = "embassy-futures"
 version = "0.1.2"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -480,12 +452,12 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 
 [[package]]
 name = "embassy-net-driver-channel"
 version = "0.3.2"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -495,7 +467,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.9.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -523,7 +495,7 @@ dependencies = [
  "nb 1.1.0",
  "pio",
  "rand_core 0.6.4",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "rp-pac",
  "rp2040-boot2",
  "sha2-const-stable",
@@ -533,7 +505,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.7.2"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -546,7 +518,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.5.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -561,7 +533,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.1"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "document-features",
 ]
@@ -569,7 +541,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-utils"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "embassy-executor-timer-queue",
  "heapless 0.8.0",
@@ -578,7 +550,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb"
 version = "0.5.1"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -594,7 +566,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#3214021ed5ae17b96ac006c0f460e222502e411d"
+source = "git+https://github.com/embassy-rs/embassy?rev=3214021ed5ae17b96ac006c0f460e222502e411d#3214021ed5ae17b96ac006c0f460e222502e411d"
 dependencies = [
  "defmt",
  "embedded-io-async",
@@ -667,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "ena"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
 ]
@@ -688,15 +660,15 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed"
-version = "1.29.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707070ccf8c4173548210893a0186e29c266901b71ed20cd9e2ca0193dfe95c3"
+checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
 dependencies = [
  "az",
  "bytemuck",
@@ -718,15 +690,15 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "generator"
@@ -818,6 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32 0.3.1",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -835,9 +808,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -854,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -901,9 +874,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "litrs"
@@ -950,29 +923,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "munge"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
-dependencies = [
- "munge_macro",
-]
-
-[[package]]
-name = "munge_macro"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nb"
@@ -1015,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1025,20 +978,20 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "panic-probe"
@@ -1106,9 +1059,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pio"
@@ -1155,14 +1108,14 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 dependencies = [
  "critical-section",
 ]
@@ -1203,54 +1156,25 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rancor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
-dependencies = [
- "ptr_meta",
 ]
 
 [[package]]
@@ -1261,9 +1185,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "redox_syscall"
@@ -1271,14 +1195,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1288,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1299,48 +1223,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "rend"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
-dependencies = [
- "bytecheck",
-]
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
-
-[[package]]
-name = "rkyv"
-version = "0.8.12"
-source = "git+https://github.com/rukai/rkyv?branch=add_support_for_arraystring#075aa221d0eb0a71d7e999e65735d1ca298ecc47"
-dependencies = [
- "arrayvec",
- "bytecheck",
- "munge",
- "ptr_meta",
- "rancor",
- "rend",
- "rkyv_derive",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.8.12"
-source = "git+https://github.com/rukai/rkyv?branch=add_support_for_arraystring#075aa221d0eb0a71d7e999e65735d1ca298ecc47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rp-pac"
@@ -1454,7 +1345,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1489,16 +1380,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -1594,7 +1479,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1610,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1639,22 +1524,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1685,7 +1570,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1711,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1735,9 +1620,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -1876,20 +1761,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]

--- a/dpedal_firmware/Cargo.toml
+++ b/dpedal_firmware/Cargo.toml
@@ -15,12 +15,12 @@ defmt = "1"
 defmt-rtt = "1"
 
 
-embassy-futures = { git = "https://github.com/embassy-rs/embassy"}
-embassy-rp = { git = "https://github.com/embassy-rs/embassy", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-usb = { git = "https://github.com/embassy-rs/embassy", features = ["defmt"] }
-embassy-time = { git = "https://github.com/embassy-rs/embassy"}
-embassy-sync = { git = "https://github.com/embassy-rs/embassy"}
+embassy-futures = { git = "https://github.com/embassy-rs/embassy", rev = "3214021ed5ae17b96ac006c0f460e222502e411d" }
+embassy-rp = { git = "https://github.com/embassy-rs/embassy", rev = "3214021ed5ae17b96ac006c0f460e222502e411d", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "3214021ed5ae17b96ac006c0f460e222502e411d", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-usb = { git = "https://github.com/embassy-rs/embassy", rev = "3214021ed5ae17b96ac006c0f460e222502e411d", features = ["defmt"] }
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "3214021ed5ae17b96ac006c0f460e222502e411d" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "3214021ed5ae17b96ac006c0f460e222502e411d" }
 
 # embassy-futures = "0.1.2"
 # embassy-rp = { version = "0.8.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp2040"] }
@@ -31,10 +31,9 @@ embassy-sync = { git = "https://github.com/embassy-rs/embassy"}
 usbd-hid = "0.9.0"
 portable-atomic = { version = "1.11.0", features = ["critical-section"] }
 static_cell = "2.1.1"
-rkyv = { version = "0.8.10", default-features = false, features = ["arrayvec-0_7", "bytecheck"], git = "https://github.com/rukai/rkyv", branch = "add_support_for_arraystring" }
 dpedal_config = { path = "../dpedal_config"}
 postcard = "1.1.3"
-arrayvec = { version = "0.7.6", default-features = false, features = ["serde"] }
+heapless = { version = "0.8", default-features = false, features = ["serde"] }
 
 [profile.release]
 codegen-units = 1

--- a/dpedal_firmware/src/config.rs
+++ b/dpedal_firmware/src/config.rs
@@ -1,13 +1,12 @@
-use arrayvec::ArrayVec;
 use defmt::error;
-use dpedal_config::{ArchivedConfig, CONFIG_OFFSET, CONFIG_SIZE, Config, PICO_FLASH_SIZE};
+use dpedal_config::{CONFIG_OFFSET, CONFIG_SIZE, Config, PICO_FLASH_SIZE};
 use embassy_rp::{
     Peri,
     flash::{Blocking, Flash},
     peripherals::FLASH,
 };
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, watch::Watch};
-use rkyv::{rancor::Failure, util::Align};
+use heapless::Vec;
 
 pub static CONFIG: Mutex<CriticalSectionRawMutex, Option<Config>> = Mutex::new(None);
 pub static CONFIG_UPDATED: Watch<CriticalSectionRawMutex, (), 2> = Watch::new();
@@ -36,13 +35,12 @@ impl ConfigFlash {
     async fn load_inner(&mut self) -> Result<(), ()> {
         let mut config_lock = CONFIG.lock().await;
         let bytes = self.load_config_bytes_from_flash()?;
-        let archive = rkyv::api::low::access::<ArchivedConfig, Failure>(&bytes).map_err(|_| ())?;
-        *config_lock = Some(rkyv::api::low::deserialize::<_, Failure>(archive).map_err(|_| ())?);
+        *config_lock = Some(postcard::from_bytes::<Config>(&bytes).map_err(|_| ())?);
 
         Ok(())
     }
 
-    pub fn load_config_bytes_from_flash(&mut self) -> Result<Align<ArrayVec<u8, CONFIG_SIZE>>, ()> {
+    pub fn load_config_bytes_from_flash(&mut self) -> Result<Vec<u8, CONFIG_SIZE>, ()> {
         // TODO: reduce stack usage
         let mut bytes = [0u8; CONFIG_SIZE];
         self.flash
@@ -56,20 +54,17 @@ impl ConfigFlash {
             return Err(());
         }
 
-        Ok(Align(ArrayVec::from_iter(
-            bytes[4..4 + size].iter().cloned(),
-        )))
+        Vec::from_slice(&bytes[4..4 + size]).map_err(|_| ())
     }
 
     pub fn check_valid_config(&self, bytes: &[u8]) -> Result<(), ()> {
-        let archive = rkyv::api::low::access::<ArchivedConfig, Failure>(bytes).map_err(|_| ())?;
-        rkyv::api::low::deserialize::<_, Failure>(archive).map_err(|_| ())?;
+        postcard::from_bytes::<Config>(bytes).map_err(|_| ())?;
         Ok(())
     }
 
     pub async fn store_config_bytes_to_flash_and_reload_config(
         &mut self,
-        bytes: &ArrayVec<u8, CONFIG_SIZE>,
+        bytes: &Vec<u8, CONFIG_SIZE>,
     ) -> Result<(), ()> {
         let size = bytes.len();
         if size > CONFIG_SIZE {
@@ -88,9 +83,9 @@ impl ConfigFlash {
             .unwrap();
 
         {
-            let mut final_bytes: ArrayVec<u8, CONFIG_SIZE> =
-                ArrayVec::from_iter(size.to_be_bytes());
-            final_bytes.extend(bytes.iter().cloned());
+            let mut final_bytes: Vec<u8, CONFIG_SIZE> =
+                Vec::from_slice(&(size as u32).to_be_bytes()).unwrap();
+            final_bytes.extend_from_slice(bytes).unwrap();
             self.flash
                 .blocking_write(CONFIG_OFFSET as u32, &final_bytes)
                 .unwrap();

--- a/dpedal_firmware/src/input.rs
+++ b/dpedal_firmware/src/input.rs
@@ -1,14 +1,14 @@
 use crate::config::{CONFIG, CONFIG_UPDATED};
 use crate::mapping_state::MappingState;
-use arrayvec::ArrayVec;
 use core::ops::ControlFlow;
 use dpedal_config::{DpedalInput, MAX_MAPPINGS, MAX_PROFILES, Profile};
 use embassy_rp::gpio::{AnyPin, Input, Pin, Pull};
 use embassy_rp::{Peri, PeripheralType};
 use embassy_time::Timer;
+use heapless::Vec;
 use static_cell::StaticCell;
 
-static PROFILES: StaticCell<ArrayVec<Profile, MAX_PROFILES>> = StaticCell::new();
+static PROFILES: StaticCell<Vec<Profile, MAX_PROFILES>> = StaticCell::new();
 
 pub struct Inputs {
     pins: [Option<Peri<'static, AnyPin>>; 30],
@@ -77,7 +77,9 @@ impl Inputs {
 
                 // Restore mapping state to full length in case it was cleared earlier
                 while profile.mappings.len() > state.mapping_states.len() {
-                    state.mapping_states.push(MappingState::new());
+                    if state.mapping_states.push(MappingState::new()).is_err() {
+                        defmt::panic!("mapping state overflow");
+                    }
                 }
 
                 for (i, mapping) in profile.mappings.iter().enumerate() {
@@ -102,14 +104,14 @@ pub(crate) struct State {
     /// The index of the currently selected profile
     pub(crate) current_profile: u8,
     /// Tracks press/release state for each mapping in the current profile
-    pub(crate) mapping_states: ArrayVec<MappingState, MAX_MAPPINGS>,
+    pub(crate) mapping_states: Vec<MappingState, MAX_MAPPINGS>,
 }
 
 impl State {
     fn new() -> Self {
         State {
             current_profile: 0,
-            mapping_states: ArrayVec::new(),
+            mapping_states: Vec::new(),
         }
     }
 }

--- a/dpedal_firmware/src/usb.rs
+++ b/dpedal_firmware/src/usb.rs
@@ -1,12 +1,13 @@
-use arrayvec::ArrayString;
 use core::sync::atomic::{AtomicBool, Ordering};
 use defmt::*;
+use dpedal_config::MAX_NICKNAME_LEN;
 use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, InterruptHandler};
 use embassy_rp::{Peri, bind_interrupts};
 use embassy_usb::class::hid::{ReportId, RequestHandler};
 use embassy_usb::control::OutResponse;
 use embassy_usb::{Builder, Config, Handler};
+use heapless::String;
 use static_cell::StaticCell;
 
 use crate::config::CONFIG;
@@ -25,19 +26,19 @@ pub async fn usb_builder(usb: Peri<'static, USB>) -> Builder<'static, Driver<'st
     static BOS_DESC: StaticCell<[u8; 256]> = StaticCell::new();
     static MSOS_DESC: StaticCell<[u8; 1024]> = StaticCell::new();
     static CONTROL_BUF: StaticCell<[u8; 128]> = StaticCell::new();
-    static PRODUCT_NAME: StaticCell<ArrayString<70>> = StaticCell::new();
+    static PRODUCT_NAME: StaticCell<String<{ MAX_NICKNAME_LEN + 20 }>> = StaticCell::new();
 
     let mut config = Config::new(0xc0de, 0xcafe);
     config.manufacturer = Some("Rukai");
-    let product = PRODUCT_NAME.init(ArrayString::from("DPedal").unwrap());
-    let nickname = CONFIG.lock().await.as_ref().unwrap().nickname;
+    let product = PRODUCT_NAME.init(String::try_from("DPedal").unwrap());
+    let nickname = CONFIG.lock().await.as_ref().unwrap().nickname.clone();
     if !nickname.is_empty() {
-        product.push_str(" - ");
-        product.push_str(&nickname);
+        product.push_str(" - ").unwrap();
+        product.push_str(&nickname).unwrap();
     }
     match env!("PROFILE") {
         "release" => {}
-        _ => product.push_str(" (debug build)"),
+        _ => product.push_str(" (debug build)").unwrap(),
     }
     config.product = Some(product);
     config.serial_number = None;

--- a/dpedal_firmware/src/web_config.rs
+++ b/dpedal_firmware/src/web_config.rs
@@ -114,16 +114,14 @@ impl WebConfig {
                 }
             };
             let response = match request {
-                Request::GetConfig => Response::GetConfig(
-                    self.config_flash
-                        .load_config_bytes_from_flash()
-                        .map(|x| x.0),
-                ),
-                Request::SetConfig(array_vec) => {
-                    defmt::info!("set config {:?}", array_vec.as_ref());
+                Request::GetConfig => {
+                    Response::GetConfig(self.config_flash.load_config_bytes_from_flash())
+                }
+                Request::SetConfig(config_bytes) => {
+                    defmt::info!("set config {:?}", config_bytes.as_slice());
                     if let Err(()) = self
                         .config_flash
-                        .store_config_bytes_to_flash_and_reload_config(&array_vec)
+                        .store_config_bytes_to_flash_and_reload_config(&config_bytes)
                         .await
                     {
                         // TODO: return error over protocol

--- a/dpedal_flash/Cargo.toml
+++ b/dpedal_flash/Cargo.toml
@@ -14,10 +14,10 @@ goblin = "0.9.3"
 miette = { version = "7.4.0", features = ["fancy"] }
 dpedal_config = { path = "../dpedal_config" }
 kdl = "6.3.3"
-kdl_config = { git = "https://github.com/rukai/kdl_config" }
+kdl_config = { git = "https://github.com/rukai/kdl_config", features = ["heapless_08"] }
 kdl_config_derive = { git = "https://github.com/rukai/kdl_config" }
-arrayvec = "0.7.6"
-rkyv = { workspace = true, features = ["alloc"] }
+heapless = { workspace = true }
+postcard = { version = "1.1.3", features = ["use-std"] }
 
 # workaround https://gitlab.com/robigalia/ssmarshal/-/merge_requests/2
 # TODO: lets just eradicate this unmaintained thing from the dep tree entirely

--- a/dpedal_flash/src/config.rs
+++ b/dpedal_flash/src/config.rs
@@ -1,4 +1,3 @@
-use arrayvec::{ArrayString, ArrayVec};
 use dpedal_config::{
     ComputerInput, Config, DpedalInput, KeyboardInput, MAX_COMPUTER_INPUTS, MAX_DPEDAL_INPUTS,
     MAX_MAPPINGS, MAX_NICKNAME_LEN, MAX_PIN_REMAPPINGS, MAX_PROFILES, MappingMode, MouseInput,
@@ -10,12 +9,11 @@ use kdl_config::{
 };
 use kdl_config_derive::{KdlConfig, KdlConfigFinalize};
 use miette::{IntoDiagnostic, NamedSource, miette};
-use rkyv::rancor::Error;
 use std::{path::PathBuf, str::FromStr};
 
 pub fn encode_config(config: &Config) -> miette::Result<Vec<u8>> {
-    let bytes = rkyv::to_bytes::<Error>(config).map_err(|e| miette!(e))?;
-    let mut result = vec![];
+    let bytes = postcard::to_stdvec(config).map_err(|e| miette!(e))?;
+    let mut result = Vec::new();
     result.extend((bytes.len() as u32).to_be_bytes());
     result.extend(bytes.iter());
     Ok(result)
@@ -62,12 +60,12 @@ fn load_source(path: Option<PathBuf>) -> miette::Result<NamedSource<String>> {
 #[kdl_config_finalize_into = "dpedal_config::Config"]
 pub struct ConfigKdl {
     pub version: Parsed<u32>,
-    pub nickname: Parsed<ArrayString<MAX_NICKNAME_LEN>>,
+    pub nickname: Parsed<heapless::String<MAX_NICKNAME_LEN>>,
     pub device: Parsed<DeviceKdl>,
     pub color: Parsed<u32>,
-    pub profiles: Parsed<ArrayVec<Parsed<ProfileKdl>, MAX_PROFILES>>,
+    pub profiles: Parsed<heapless::Vec<Parsed<ProfileKdl>, MAX_PROFILES>>,
     // TODO: add validation: no duplicate pins (including default values), valid pin range
-    pub pin_remappings: Parsed<ArrayVec<Parsed<PinRemappingKdl>, MAX_PIN_REMAPPINGS>>,
+    pub pin_remappings: Parsed<heapless::Vec<Parsed<PinRemappingKdl>, MAX_PIN_REMAPPINGS>>,
 }
 
 #[derive(KdlConfig, KdlConfigFinalize, Default, Debug)]
@@ -81,14 +79,14 @@ pub struct PinRemappingKdl {
 #[derive(KdlConfig, KdlConfigFinalize, Default, Debug)]
 #[kdl_config_finalize_into = "dpedal_config::Profile"]
 pub struct ProfileKdl {
-    pub mappings: Parsed<ArrayVec<Parsed<MappingKdl>, MAX_MAPPINGS>>,
+    pub mappings: Parsed<heapless::Vec<Parsed<MappingKdl>, MAX_MAPPINGS>>,
 }
 
 #[derive(Default, Debug)]
 pub struct MappingKdl {
-    pub input_set: ArrayVec<dpedal_config::DpedalInput, MAX_DPEDAL_INPUTS>,
+    pub input_set: heapless::Vec<dpedal_config::DpedalInput, MAX_DPEDAL_INPUTS>,
     pub mode: MappingMode,
-    pub output_sequence: ArrayVec<dpedal_config::ComputerInput, MAX_COMPUTER_INPUTS>,
+    pub output_sequence: heapless::Vec<dpedal_config::ComputerInput, MAX_COMPUTER_INPUTS>,
 }
 
 impl KdlConfigFinalize for MappingKdl {
@@ -168,7 +166,7 @@ impl KdlConfig for MappingKdl {
                         valid: false,
                     };
                 };
-                let input = ArrayVec::from_iter([input]);
+                let input = heapless::Vec::from_slice(&[input]).unwrap();
 
                 let Some((ty, sub_ty)) = output.split_once("-") else {
                     diagnostics.push(ParseDiagnostic {
@@ -243,7 +241,7 @@ impl KdlConfig for MappingKdl {
                         };
                     }
                 };
-                let output_sequence = ArrayVec::from_iter([output]);
+                let output_sequence = heapless::Vec::from_slice(&[output]).unwrap();
                 Parsed {
                     value: MappingKdl {
                         input_set: input,

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -6,8 +6,9 @@ set -e
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-cargo hack --feature-powerset clippy --all-targets --locked -- -D warnings
 cd dpedal_config_web_app
 cargo hack --feature-powerset clippy --all-targets --locked -- -D warnings
 cd ../dpedal_firmware
 cargo hack --feature-powerset clippy --locked -- -D warnings
+cd ..
+cargo hack --feature-powerset clippy --all-targets --locked -- -D warnings


### PR DESCRIPTION
This happens to remove 1KB from the firmware size, but main point is to enable usage of https://github.com/tweedegolf/sequential-storage down the line, which will integrate better if I use heapless and postcard.

In general, heapless is designed more for embedded, and provides other types that could be helpful in the future.